### PR TITLE
Change shebang

### DIFF
--- a/impl_me.rb
+++ b/impl_me.rb
@@ -1,4 +1,4 @@
-#!/bin/usr/ruby -w
+#!/usr/bin/env ruby -w
 
 require 'fileutils'
 require 'tempfile'

--- a/impl_me.rb
+++ b/impl_me.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -w
+#!/usr/bin/env -S ruby -w
 
 require 'fileutils'
 require 'tempfile'


### PR DESCRIPTION
Make the shebang more portable. Using env will ask to use the end user's preferred version of ruby rather than dictating a path to the end user.